### PR TITLE
Fix lambda_lossPET when not using PET

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The full dataset can be found at huggingface.co/datasets/m1balcerak/GliODIL (htt
 
 ### Data format:
 
-Segmentations follow the BraTS toolkit segmentation convention [1], with voxel values representing different tumor regions: 1.0 for enhancing core, 3.0 for edema, and 4.0 for necrotic core. The command creates a subdirectory with results in a given directory. If you do not have brain tissue segmentation, you can use the s3 tool (https://github.com/JanaLipkova/s3 or github.com/andeleyev/brain-tumor-tissue-reconstruction).
+Segmentations follow the BraTS toolkit segmentation convention [1], with voxel values representing different tumor regions: 1.0 for necrotic core, 3.0 for edema, and 4.0 for enhancing core. The command creates a subdirectory with results in a given directory. If you do not have brain tissue segmentation, you can use the s3 tool (https://github.com/JanaLipkova/s3 or github.com/andeleyev/brain-tumor-tissue-reconstruction).
 
 # Cite
 If you use this tool, please cite the following paper:

--- a/spatial_brain_tumor_concentration_estimation/estimateTumorConcentration.py
+++ b/spatial_brain_tumor_concentration_estimation/estimateTumorConcentration.py
@@ -27,9 +27,7 @@ def train():
 
         if wandb.config.petImagePath == "":
             petImageNumpy = np.zeros_like(tumorSeg)
-            config.lambda_lossPET = 0
-
-        if config.lambda_lossPET > 0:
+        else:
             necrotic = np.zeros_like(tumorSeg)
             necrotic[tumorSeg == 4] = 1
             petImageNumpy = nib.load(wandb.config.petImagePath).get_fdata()
@@ -189,8 +187,8 @@ def train():
         #nib.save(nib.Nifti1Image(torch.abs(physicsLoss.clone()).detach().cpu().numpy()[0,0], affine), savePathPatient + "/voxelWiseLoss.nii.gz")
         
 
-def estimateBrainTumorConcentration(tumorSegmentationPath, wmPath, gmPath, csfPath,  petImagePath, savePath, recurrencePath = ""):
-    
+def estimateBrainTumorConcentration(tumorSegmentationPath, wmPath, gmPath, csfPath, savePath, petImagePath = "", recurrencePath = ""):
+
     parametersDict = {
                 "tumorSegPath": {
                     "value": tumorSegmentationPath
@@ -229,7 +227,7 @@ def estimateBrainTumorConcentration(tumorSegmentationPath, wmPath, gmPath, csfPa
                     'value':1000 # Fixed value
                 },
                 'lambda_lossPET': {
-                    'value': 1  # Fixed value
+                    'value': 0 if petImagePath == "" else 1
                 },
                 'num_epochs': {
                     'value': 500 # Fixed number of epochs

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -252,7 +252,7 @@
    ],
    "source": [
     "from spatial_brain_tumor_concentration_estimation import estimateTumorConcentration\n",
-    "estimateTumorConcentration.estimateBrainTumorConcentration(tumorSegmentationPath, wmPath, gmPath, csfPath, petImagePath, savePath, recurrencePath)"
+    "estimateTumorConcentration.estimateBrainTumorConcentration(tumorSegmentationPath, wmPath, gmPath, csfPath, savePath, petImagePath, recurrencePath)"
    ]
   },
   {


### PR DESCRIPTION
- Set lambda_lossPET in estimateBrainTumorConcentration instead of train(), preventing a bug when not using PET.

- Fixed typo in README regarding tumor segmentation labels 